### PR TITLE
Mostly cleanup, and ...

### DIFF
--- a/scripts/justbuild.sh
+++ b/scripts/justbuild.sh
@@ -1,3 +1,20 @@
 #!/bin/sh -ex
 # compile and package the Tez
-mvn package -Dtar -Dhadoop.version=${HADOOP_VERSION} -DskipTests -Dmaven.javadoc.skip=true
+#mvn package -Dtar -Dhadoop.version=${HADOOP_VERSION} -DskipTests -Dmaven.javadoc.skip=true
+#
+env
+MVN_SKIPTESTS_BOOL=${SKIPTESTS_BOOL:-false}
+if [ "${MVN_SKIPTESTS_BOOL}" != "true" ] ; then
+    MVN_SKIPTESTS_BOOL=false
+fi
+
+MVN_IGNORE_TESTFAILURES_BOOL=${IGNORE_TESTFAILURES_BOOL:-false}
+if [ "${MVN_IGNORE_TESTFAILURES_BOOL}" != "true" ] ; then
+    MVN_IGNORE_TESTFAILURES_BOOL=false
+fi
+
+mvn clean -PcleanUICache package -Dtar \
+-Dmaven.test.skip=${MVN_SKIPTESTS_BOOL} -DskipTests=${MVN_SKIPTESTS_BOOL} \
+-Dmaven.test.failure.ignore=${MVN_IGNORE_TESTFAILURES_BOOL} -DtestFailureIgnore=${MVN_IGNORE_TESTFAILURES_BOOL} \
+-Dmaven.javadoc.skip=true \
+${JUSTBUILD_EXTRA_OPTS}

--- a/scripts/justinstall.sh
+++ b/scripts/justinstall.sh
@@ -6,7 +6,7 @@ echo "Packaging tez rpm with name ${RPM_NAME} with version ${ALTISCALE_VERSION}-
 
 export RPM_BUILD_DIR=${INSTALL_DIR}/opt/tez-${TEZ_VERSION}
 mkdir --mode=0755 -p ${RPM_BUILD_DIR}
-mkdir --mode=0755 -p ${INSTALL_DIR}/etc/tez
+mkdir --mode=0755 -p ${INSTALL_DIR}/etc/tez-${TEZ_VERSION}
 cd ${RPM_BUILD_DIR}
 export DIST_DIR=${WORKSPACE}/tez/tez-dist/target
 mkdir --mode=0755 lib
@@ -21,7 +21,7 @@ fpm --verbose \
 --maintainer support@altiscale.com \
 --vendor Altiscale \
 --provides ${RPM_NAME} \
---description "${RPM_DESCRIPTION}" \
+--description "$(printf "${RPM_DESCRIPTION}")" \
 --replaces alti-tez-${ARTIFACT_VERSION} \
 --replaces vcc-tez \
 --url "${GITREPO}" \


### PR DESCRIPTION
- remove /etc/tez to avoid potential conflicts with previous rpms.
- remove \n\n from RPM description
- always make a clean build, also for the UI
- allow running tests and skipping test failures (optionally)
- allow for extra options
- remove explicit overwrite for the hadoop.version, there are more test
failures when build against Hadoop 2.7.2 than when build against Hadoop
2.6.0 (the default)